### PR TITLE
Disable testing for `aarch64-apple-darwin`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,3 +85,7 @@ jobs:
     - name: Test using cross
       if: "matrix.use-cross"
       run: cross test --target ${{ matrix.target }}
+
+    - name: Build for aarch64-apple-darwin
+      if: ${{ matrix.target == 'aarch64-apple-darwin' }}
+      run: cargo build --target ${{ matrix.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Test
-      if: "!matrix.use-cross"
+      if: ${{ !matrix.use-cross && matrix.target != 'aarch64-apple-darwin' }}
       run: cargo test --target ${{ matrix.target }}
 
     - name: Test using cross


### PR DESCRIPTION
Since the github action only supports `x86_64-apple-darwin` and it
cannot be used to compile program built for M1.

Fixed #4 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>